### PR TITLE
fix for issue #79

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,3 +68,4 @@ Collate:
     'package-installation-methods.R'
     'sessionInfo-localbuild-methods.R'
     'utility-functions.R'
+Remotes: wch/harbor

--- a/R/package-installation-methods.R
+++ b/R/package-installation-methods.R
@@ -127,9 +127,16 @@
     #------------------------------------------------------------------------(end of section)
     
     # determine package dependencies (if applicable by given platform)
-    pkg_dep <- .find_system_dependencies(pkg_names, platform = platform, package_version = package_versions, soft = soft)
-    #workaround for issue https://github.com/r-hub/sysreqsdb/issues/22 TODO: remove if not needed anymore
-    pkg_dep <- unlist(stringr::str_split(pkg_dep, pattern = " "))
+    pkg_dep <- .find_system_dependencies(pkg_names, 
+                                         platform = platform, 
+                                         package_version = package_versions, 
+                                         soft = soft)
+    
+    # fix duplicates and parsing https://github.com/o2r-project/containerit/issues/79
+    pkg_dep_deduped <- unique(unlist(pkg_dep, use.names = FALSE))
+
+    # fix if depends come back with a space https://github.com/r-hub/sysreqsdb/issues/22
+    pkg_dep <- unlist(lapply(pkg_dep_deduped, function(x) unlist(strsplit(x, split=" "))))
     
     package_reqs <- append(package_reqs, pkg_dep)
     


### PR DESCRIPTION
This fixes the parsing on the system dependencies list returned from `.find_system_dependencies`  as reported here: https://github.com/o2r-project/containerit/issues/79

It also removes a dependency on `stringr::str_split` which was previously put in for a fix to this issue:
https://github.com/r-hub/sysreqsdb/issues/22 and replaces it with a base R `strsplit`

On my local tests it fixes a dockerfile that looks like this:

```
FROM rocker/r-ver:3.4.0
LABEL maintainer="mark"
RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update \
 && apt-get install -y "libcairo2-dev", \
	"libcurl4-openssl-dev", \
	"libcurl4-openssl-dev") \
	"libgmp-dev", \
	"libpng-dev", \
	"libssl-dev", \
	"libssl-dev") \
	"libxml2-dev", \
	"libxml2-dev") \
	"make", \
	"make") \
	"pandoc \
	"zlib1g-dev", \
	"zlib1g-dev") \
	c("libcurl4-openssl-dev", \
	c("libssl-dev", \
	c("libxml2-dev", \
	c("make", \
	c("pandoc \
	character(0) \
	pandoc \
	pandoc-citeproc \
	pandoc-citeproc", \
	pandoc-citeproc")
RUN ["install2.r", "-r 'https://cloud.r-project.org'", "googleCloudStorageR", "googleAuthR", "Rcpp", "assertthat", "digest", "crayon", "withr", "mime", "R6", "jsonlite", "xtable", "magrittr", "httr", "curl", "testthat", "devtools", "readr", "hms", "shiny", "httpuv", "memoise", "htmltools", "openssl", "tibble", "remotes"]
RUN ["installGithub.r", "hadley/rlang@c351186"]
WORKDIR /payload/
COPY [".", "./"]
CMD ["R", "--vanilla", "-f", "schedule.R"]
```

to this:

```
FROM rocker/r-ver:3.4.0
LABEL maintainer="mark"
RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update \
 && apt-get install -y libcairo2-dev \
	libcurl4-openssl-dev \
	libgmp-dev \
	libpng-dev \
	libssl-dev \
	libxml2-dev \
	make \
	pandoc \
	pandoc-citeproc \
	zlib1g-dev
RUN ["install2.r", "-r 'https://cloud.r-project.org'", "googleCloudStorageR", "googleAuthR", "Rcpp", "assertthat", "digest", "crayon", "withr", "mime", "R6", "jsonlite", "xtable", "magrittr", "httr", "curl", "testthat", "devtools", "readr", "hms", "shiny", "httpuv", "memoise", "htmltools", "openssl", "tibble", "remotes"]
RUN ["installGithub.r", "hadley/rlang@c351186"]
WORKDIR /payload/
COPY ["gineR/schedulescripts", "gineR/schedulescripts/"]
CMD ["R", "--vanilla", "-f", "schedule.R"]
``