### PR TITLE
[WIP] Add packrat support

### DIFF
--- a/R/dockerfile.R
+++ b/R/dockerfile.R
@@ -311,7 +311,7 @@ dockerfileFromSession.sessionInfo <- function(session,
              version <- NA
              source <- NA
 
-             #check if package come from CRAN or GitHub
+             #check if package come from CRAN, GitHub or Bioconductor
              if ("Repository" %in% names(pkg) &&
                  stringr::str_detect(pkg$Repository, "(?i)CRAN")) {
                source <- "CRAN"
@@ -320,7 +320,12 @@ dockerfileFromSession.sessionInfo <- function(session,
                         stringr::str_detect(pkg$RemoteType, "(?i)github")) {
                source <- "github"
                version <- getGitHubRef(name, pkgs)
-             } else {
+             } else if ("git_url" %in% names(pkg) &&
+                        stringr::str_detect(pkg$git_url, "bioconductor")) {
+               source <- "Bioconductor"
+               version <- pkg$Version
+             }
+               else {
                warning("Failed to identify a source for package ", name,
                        ". Therefore the package cannot be installed in the Docker image.\n")
              }

--- a/R/package-installation-methods.R
+++ b/R/package-installation-methods.R
@@ -81,18 +81,19 @@ add_install_instructions <- function(dockerfile,
     pkgs_bioc <- pkgs[stringr::str_detect(string = pkgs$source, pattern = "Bioconductor"),]
     if (nrow(pkgs_bioc) > 0) {
       if (versioned_packages) {
-        futile.logger::flog.info("Adding versioned Bioconductor packages: %s", toString(pkgs_bioc$name))
-        addInstruction(dockerfile) <- Run("install2.r", "versions")
-        addInstruction(dockerfile) <- versioned_install_instructions(pkgs_bioc)
-      } else {
-        bioc_packages <- sort(as.character(unlist(pkgs_bioc$name))) # sort, to increase own reproducibility
-        futile.logger::flog.info("Adding Bioconductor packages: %s", toString(bioc_packages))
-        repos = as.character(BiocManager::repositories())
-        addInstruction(dockerfile) <- Run("install2.r", params = c(sprintf("-r %s -r %s -r%s -r%s",
-                                                                           repos[1], repos[2],
-                                                                           repos[3], repos[4]),
-                                                                   bioc_packages))
+        # futile.logger::flog.info("Adding versioned Bioconductor packages: %s", toString(pkgs_bioc$name))
+        # addInstruction(dockerfile) <- Run("install2.r", "versions")
+        # addInstruction(dockerfile) <- versioned_install_instructions(pkgs_bioc[c("name", "version")])
+        message("A versioned install for Bioconductor packages is not supported. Please use the R version of the respective Bioconductor release.")
       }
+      bioc_packages <- sort(as.character(unlist(pkgs_bioc$name))) # sort, to increase own reproducibility
+      futile.logger::flog.info("Adding Bioconductor packages: %s", toString(bioc_packages))
+      repos = as.character(BiocManager::repositories())
+      addInstruction(dockerfile) <- Run("install2.r", params = c(sprintf("-r %s -r %s -r%s -r%s",
+                                                                         repos[1], repos[2],
+                                                                         repos[3], repos[4]),
+                                                                 bioc_packages))
+
     } else futile.logger::flog.debug("No Bioconductor packages to add.")
 
     # 3. add installation instruction for CRAN packages
@@ -101,7 +102,7 @@ add_install_instructions <- function(dockerfile,
       if (versioned_packages) {
         futile.logger::flog.info("Adding versioned CRAN packages: %s", toString(pkgs_cran$name))
         addInstruction(dockerfile) <- Run("install2.r", "versions")
-        addInstruction(dockerfile) <- versioned_install_instructions(pkgs_cran)
+        addInstruction(dockerfile) <- versioned_install_instructions(pkgs_cran[c("name", "version")])
       } else {
         cran_packages <- sort(as.character(unlist(pkgs_cran$name))) # sort, to increase own reproducibility
         futile.logger::flog.info("Adding CRAN packages: %s", toString(cran_packages))
@@ -127,7 +128,7 @@ add_install_instructions <- function(dockerfile,
     # 4. add installation instruction for GitHub packages
     pkgs_gh <- pkgs[stringr::str_detect(string = pkgs$source, stringr::regex("GitHub", ignore_case = TRUE)),]
     if (nrow(pkgs_gh) > 0) {
-      github_packages <- sort(as.character(unlist(pkgs_gh$version))) # sort, to increase own reproducibility
+      github_packages <- sort(as.character(unlist(pkgs_gh$name))) # sort, to increase own reproducibility
       futile.logger::flog.info("Adding GitHub packages: %s", toString(github_packages))
       addInstruction(dockerfile) <- Run("installGithub.r", github_packages)
     }
@@ -146,13 +147,14 @@ versioned_install_instruction <- function(name, version) {
 
 # expects a data.frame with columns name and version
 versioned_install_instructions <- function(pkgs) {
+
   .pkgs_sorted <- pkgs[order(pkgs$name),] # sort, to increase own reproducibility
 
   .installInstructions <- apply(X = .pkgs_sorted,
                                 FUN = function(pkg) {
                                   paste0('versions::install.versions(\'', pkg["name"], '\', \'' , pkg["version"], '\')')
                                 }, MARGIN = 1)
-  .params <- c(rbind(rep("-e", 2), .installInstructions))
+  .params <- suppressWarnings(c(rbind(rep("-e", 2), .installInstructions)))
   .instruction <- Run(exec = "Rscript", params = .params)
   return(.instruction)
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM rocker/r-ver:3.5.1
+LABEL maintainer="pjs"
+RUN ["install2.r", "-r https://bioconductor.org/packages/3.8/bioc -r https://bioconductor.org/packages/3.8/data/annotation -rhttps://bioconductor.org/packages/3.8/data/experiment -rhttps://bioconductor.org/packages/3.8/workflows", "BiocGenerics"]
+RUN ["install2.r", "versions"]
+RUN ["Rscript", "-e", "versions::install.versions('BBmisc', '1.11')", "-e", "versions::install.versions('BH', '1.66.0-1')", "-e", "versions::install.versions('zoo', '1.8-3')"]
+WORKDIR /payload/
+CMD ["R"]

--- a/inst/docker/Dockerfile.local
+++ b/inst/docker/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM rocker/geospatial:3.4.4
+FROM rocker/geospatial:3.5.1
 LABEL maintainer="o2r project <http://o2r.info>"
 
 RUN apt-get update \


### PR DESCRIPTION
This build upon #136.

If `dockerfile(packrat = TRUE)` is set, it scrapes `packrat/packrat.lock` and gathers all required package information.

If you check out this branch, you can do a test run by calling

```r
library("containerit")

container = dockerfile(".", packrat = TRUE)
write(container, "docker/Dockerfile")

system("cd docker && docker build -t test .")
```

This is just a proof of concept. The implementation needs more love in the following points

- Finding `packrat/packrat.lock`
- Using `packrat = TRUE` as a default if `dockerfile()` is called on a directory?
- documentation missing completely

Also, because of the way [Bioconductor works](https://tblein.eu/~tblein/development/2016/installing-a-specific-version-of-bioconductor/), a versioned install is not supported. However, as Bioconductor packages are bound to a specific R version, the scraped R version + `BiocManager::repositories()` call should make things stable.

I could think of having this approach as the overall default for `dockerfile()`.
Having a packrat lib enhances reproducibility and I think it would be a great combination to strongly point to the use of packrat in combination with `containerit`. What do you think?
