### PR TITLE
Indicate that you have a containerit::write method

### DIFF
--- a/vignettes/containerit.Rmd
+++ b/vignettes/containerit.Rmd
@@ -113,7 +113,7 @@ print(dockerfile_object)
 Instead of printing out to the console, you can also write to a file:
 
 ```{r write_df}
-write(dockerfile_object, file = tempfile(fileext = ".dockerfile"))
+containerit::write(dockerfile_object, file = tempfile(fileext = ".dockerfile"))
 ```
 
 


### PR DESCRIPTION
Because if the pkg is not attached, the user will not have access to this method, and it will fail with a cryptic error

For example, I like to do this in a workflow, without attaching the pkg:

```
dockerfile <- containerit::dockerfile()
containerit::write(dockerfile, "dockerfile")
```
But if I just do `write(dockerfile, "dockerfile")` it will fail with an error. And some users might get stuck on that. 

Just a thought!