### PR TITLE
Adding basic Dockerfile for rstudio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rocker/rstudio
+# docker build -t containerit .
+# docker run --rm -p 8787:8787 -e PASSWORD=meatballs containerit
+# open to localhost:8787, username rstudio and password set above
+RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update \
+  && apt-get install -y libcurl4-openssl-dev \
+	libssl-dev \
+	make
+RUN ["install2.r", "assertthat", "backports", "crayon", "curl", "desc", "digest", "formatR", "fs", "futile.logger", "futile.options", "htmltools", "httpuv", "jsonlite", "lambda.r", "later", "magrittr", "mime", "miniUI", "pillar", "pkgconfig", "promises", "R6", "Rcpp", "rlang", "rprojroot", "rstudioapi", "semver", "shiny", "shinyFiles", "stevedore", "stringi", "stringr", "tibble", "versions", "xtable"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update \
 	libssl-dev \
 	make
 RUN ["install2.r", "assertthat", "backports", "crayon", "curl", "desc", "digest", "formatR", "fs", "futile.logger", "futile.options", "htmltools", "httpuv", "jsonlite", "lambda.r", "later", "magrittr", "mime", "miniUI", "pillar", "pkgconfig", "promises", "remotes", "R6", "Rcpp", "rlang", "rprojroot", "rstudioapi", "semver", "shiny", "shinyFiles", "stevedore", "stringi", "stringr", "tibble", "versions", "xtable"]
+RUN apt-get update && apt-get install -y zlib1g-dev libxml2-dev
 RUN Rscript -e "remotes::install_github('o2r-project/containerit')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update \
   && apt-get install -y libcurl4-openssl-dev \
 	libssl-dev \
 	make
-RUN ["install2.r", "assertthat", "backports", "crayon", "curl", "desc", "digest", "formatR", "fs", "futile.logger", "futile.options", "htmltools", "httpuv", "jsonlite", "lambda.r", "later", "magrittr", "mime", "miniUI", "pillar", "pkgconfig", "promises", "R6", "Rcpp", "rlang", "rprojroot", "rstudioapi", "semver", "shiny", "shinyFiles", "stevedore", "stringi", "stringr", "tibble", "versions", "xtable"]
+RUN ["install2.r", "assertthat", "backports", "crayon", "curl", "desc", "digest", "formatR", "fs", "futile.logger", "futile.options", "htmltools", "httpuv", "jsonlite", "lambda.r", "later", "magrittr", "mime", "miniUI", "pillar", "pkgconfig", "promises", "remotes", "R6", "Rcpp", "rlang", "rprojroot", "rstudioapi", "semver", "shiny", "shinyFiles", "stevedore", "stringi", "stringr", "tibble", "versions", "xtable"]
+RUN Rscript -e "remotes::install_github('o2r-project/containerit')"


### PR DESCRIPTION
This pull request will add a Dockerfile to build an rstudio container for easy working with containerit. There should be instructions added to the README too, but it looks like the file says not to be edited so I'll leave that to you.

Note that I changed the recipe generated by containerit to use an rstudio base (to make an interface for the user) and I'm rebuilding and testing now.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>