### PR TITLE
Fix tests

### DIFF
--- a/R/package-installation-methods.R
+++ b/R/package-installation-methods.R
@@ -39,7 +39,7 @@ add_install_instructions <- function(dockerfile,
     pkgs <- rbind(cran_packages[!skipable,], pkgs[pkgs$source != "CRAN",])
   }
 
-  # 0. Installing github packages requires the package 'remotes'
+  # 0. Installing github packages requires the package 'remotes' (and devtools for R < 3.4, which is not suppoted), see https://github.com/eddelbuettel/littler/blob/master/inst/examples/installGithub.r#L12
   if (nrow(pkgs[pkgs$source == "github",]) > 0 && !"remotes" %in% pkgs$name) {
     pkgs <- rbind(pkgs, remotes = data.frame(name = "remotes", version = "1.1.1", source = "CRAN"))
     futile.logger::flog.debug("Added package 'remotes' to package list to be able to install from GitHub")

--- a/tests/testthat/github/DESCRIPTION
+++ b/tests/testthat/github/DESCRIPTION
@@ -1,0 +1,18 @@
+Package: containerittest
+Version: 1.2.3
+Title: Simple Features for R
+Authors@R: c(person(given = "o2",
+             family = "r",
+             role = c("aut", "cre"),
+             email = "o2r-team@uni-muenster.de"))
+Description: Test description
+License: file LICENSE
+URL: https://test.com
+Depends: methods, R (>= 3.5.0)
+Imports: graphics
+Encoding: UTF-8
+Collate: 'code.R'
+NeedsCompilation: yes
+Author: o2 r [aut, cre]
+Maintainer: o2 r <o2r-team@uni-muenster.de>
+Remotes: github::some-org/the_package

--- a/tests/testthat/package_description/DESCRIPTION
+++ b/tests/testthat/package_description/DESCRIPTION
@@ -1,6 +1,6 @@
-Package: containerittest
+Package: here
 Version: 1.2.3
-Title: Simple Features for R
+Title: Fake DESCRIPTION file for containerit testing
 Authors@R: c(person(given = "o2",
              family = "r",
              role = c("aut", "cre"),
@@ -8,7 +8,7 @@ Authors@R: c(person(given = "o2",
 Description: Test description
 License: file LICENSE
 URL: https://test.com
-Depends: methods, R (>= 3.3.0)
+Depends: methods, R (>= 3.4.0)
 Imports: graphics, grDevices, grid, Rcpp (>= 0.12.18), units (>= 0.6-0), utils
 Suggests: covr, dplyr (>= 0.8-0), ggplot2, knitr, lwgeom (>= 0.1-5), maps
 Encoding: UTF-8
@@ -17,5 +17,5 @@ Collate: 'code.R'
 NeedsCompilation: yes
 Author: o2 r [aut, cre]
 Maintainer: o2 r <o2r-team@uni-muenster.de>
-Remotes: github::r-hub/sysreqs,gitlab::test/pkg
+Remotes: github::r-hub/sysreqs,gitlab::test/pkg,github::viking/r-yaml@v2.1.17
 biocViews: Sequencing, RNASeq

--- a/tests/testthat/package_description/Dockerfile
+++ b/tests/testthat/package_description/Dockerfile
@@ -1,9 +1,9 @@
-FROM rocker/r-ver:3.3.0
+FROM rocker/r-ver:3.4.0
 LABEL maintainer="o2r"
 RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update \
   && apt-get install -y git-core \
 	libudunits2-dev
-RUN ["install2.r", "containerittest", "graphics", "grDevices", "grid", "Rcpp", "remotes", "units", "utils"]
-RUN ["installGithub.r", "r-hub/sysreqs@master"]
+RUN ["install2.r", "graphics", "grDevices", "grid", "here", "Rcpp", "remotes", "units", "utils"]
+RUN ["installGithub.r", "r-hub/sysreqs@master", "viking/r-yaml@v2.1.17"]
 WORKDIR /payload/
 CMD ["R"]

--- a/tests/testthat/package_description/Dockerfile.versioned
+++ b/tests/testthat/package_description/Dockerfile.versioned
@@ -1,11 +1,11 @@
-FROM rocker/r-ver:3.3.0
+FROM rocker/r-ver:3.4.0
 LABEL maintainer="o2r"
 RUN export DEBIAN_FRONTEND=noninteractive; apt-get -y update \
   && apt-get install -y git-core \
 	libudunits2-dev
 RUN ["install2.r", "versions"]
 RUN ["install2.r", "graphics", "grDevices", "grid", "Rcpp", "units", "utils"]
-RUN ["Rscript", "-e", "versions::install.versions('containerittest', '1.2.3')", "-e", "versions::install.versions('remotes', '1.1.1')"]
-RUN ["installGithub.r", "r-hub/sysreqs@master"]
+RUN ["Rscript", "-e", "versions::install.versions('here', '1.2.3')", "-e", "versions::install.versions('remotes', '1.1.1')"]
+RUN ["installGithub.r", "r-hub/sysreqs@master", "viking/r-yaml@v2.1.17"]
 WORKDIR /payload/
 CMD ["R"]

--- a/tests/testthat/test_find_systemrequirements.R
+++ b/tests/testthat/test_find_systemrequirements.R
@@ -2,7 +2,15 @@
 
 context("Find system requrirements")
 
+skip_if_crandeps_offline <- function() {
+  skip_if_not_installed("httr")
+  if (httr::status_code(httr::HEAD(url = "crandeps.r-pkg.org")) != 200)
+    skip("crandeps not available")
+}
+
 test_that("System requirements for sp can be detected OFFLINE and soft", {
+  skip_if_crandeps_offline()
+
   output <- capture_output(
     deps <- containerit:::.find_system_dependencies("sp",
                                       platform = containerit:::.debian_platform,
@@ -15,6 +23,8 @@ test_that("System requirements for sp can be detected OFFLINE and soft", {
 })
 
 test_that("System requirements for sp can be detected OFFLINE and unsoft", {
+  skip_if_crandeps_offline()
+
   output <- capture_output(
     deps <- containerit:::.find_system_dependencies("sp",
                                                     platform = containerit:::.debian_platform,
@@ -25,6 +35,8 @@ test_that("System requirements for sp can be detected OFFLINE and unsoft", {
 })
 
 test_that("System requirements for rgdal can be detected OFFLINE", {
+  skip_if_crandeps_offline()
+
   output <- capture_output(
     deps <- containerit:::.find_system_dependencies("rgdal",
                                                     platform = containerit:::.debian_platform,

--- a/tests/testthat/test_install_github.R
+++ b/tests/testthat/test_install_github.R
@@ -23,3 +23,24 @@ test_that("GitHub references can be retrieved for package sysreqs (test fails if
   ref <- getGitHubRef("sysreqs", c(sessionInfo()$otherPkgs, sessionInfo()$loadedOnly))
   expect_match(ref, "r-hub/sysreqs@([a-f0-9]{7})")
 })
+
+test_that("the package remotes is installed if not already in the list of packages", {
+  output <- capture_output(
+    the_dockerfile <- dockerfile(from = "github/DESCRIPTION",
+                                 maintainer = "o2r")
+  )
+  expect_true(any(stringr::str_detect(toString(the_dockerfile),
+                                      "^RUN \\[\"install2.r\", \"containerittest\", \"graphics\", \"remotes\"\\]$")))
+  expect_true(any(stringr::str_detect(toString(the_dockerfile),
+                                      "^RUN \\[\"installGithub.r\", \"some-org/the_package@master\"\\]$")))
+})
+
+test_that("the package remotes is installed in the correct version if not already in the list of packages", {
+  output <- capture_output(
+    the_dockerfile <- dockerfile(from = "github/DESCRIPTION",
+                                 maintainer = "o2r",
+                                 versioned_packages = TRUE)
+  )
+  expect_true(any(stringr::str_detect(toString(the_dockerfile),
+                                      "versions::install.versions\\('remotes', '1.1.1'\\)")))
+})

--- a/tests/testthat/test_save_workspace.R
+++ b/tests/testthat/test_save_workspace.R
@@ -3,7 +3,6 @@
 context("Save workspace and R objects (save_image - argument)")
 
 test_that("Session objects with default file name can be containerized", {
-  rm(list = ls(envir = environment()), envir = environment()) # start clean
   expect_false(file.exists(".RData"), "RData file already exists in testthat folder. Remove manually and restart test.")
 
   test_text <- "test"
@@ -37,7 +36,6 @@ test_that("Session objects with default file name can be containerized", {
 })
 
 test_that("Selected session objects with configured file name can be containerized", {
-  rm(list = ls(envir = environment()), envir = environment()) # start clean
   expect_false(file.exists("test_file.RData"), "RData file already exists in testthat folder. Remove manually and restart test.")
 
   test_text <- "test"
@@ -69,6 +67,8 @@ test_that("Selected session objects with configured file name can be containeriz
 })
 
 test_that("Program ignores unsupported input for save_image", {
+  expect_false(file.exists(".RData"), "RData file already exists in testthat folder. Remove manually and restart test.")
+
   output <- capture_output(
     expect_s4_class(dockerfile(from = sessionInfo(), save_image = data.frame()), "Dockerfile")
   )


### PR DESCRIPTION
Also only support installGithub.r for R versions where it relies on `remotes` but not on `devtools`.

If this fixes the tests, update the `v0.5.0` tag _again_.