### PR TITLE
Utilize dockerfiler::dock_from_renv() when renv.lock file is provided

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,12 @@ Authors@R:
              comment = c(ORCID = "0000-0002-6585-538X")),
       person(given = "Marc",
              family = "Greenaway",
-             role = "ctb"))
+             role = "ctb"),
+      person(given = "Josiah",
+             family = "Parry", 
+             email = "josiah.parry@gmail.com",
+             role = "ctb",
+             comment = c(ORCID = "0000-0001-9910-865X"))
 Author: Daniel Nuest [aut, cre], Matthias Hinz [aut]
 Maintainer: Daniel Nuest <daniel.nuest@uni-muenster.de>
 Description: Package R sessions, scripts, workspace directories, and R
@@ -67,7 +72,8 @@ Imports:
     stringr,
     sysreqs,
     utils,
-    versions
+    versions,
+    dockerfiler
 Suggests:
     BiocGenerics,
     codetools,

--- a/R/dockerfile.R
+++ b/R/dockerfile.R
@@ -84,10 +84,16 @@ dockerfile <- function(from = utils::sessionInfo(),
                        predetect = TRUE,
                        versioned_libs = FALSE,
                        versioned_packages = FALSE,
-                       filter_baseimage_pkgs = FALSE) {
+                       filter_baseimage_pkgs = FALSE,
+                       ...) {
     if (silent) {
       invisible(futile.logger::flog.threshold(futile.logger::WARN))
     }
+
+  if (grepl("renv.lock", from)) {
+    dock <- dockerfiler::dock_from_renv(from, ...)
+    return(dock)
+  }
 
     the_dockerfile <- NA
     originalFrom <- class(from)


### PR DESCRIPTION
NOTE: This functionality works solely with my [fork of dockerfiler](https://github.com/josiahparry/dockerfiler) as it has not been merged yet. 

This PR will utilize `dockerfiler::dock_from_renv()` when the `from` argument contains `"renv.lock"`. 

To do this, I've added a single if statement with an early return. Additionally, I've added the `. . .` argument so as to pass arguments to `dock_from_renv()` if desired. 